### PR TITLE
Update unix.t

### DIFF
--- a/unix.t
+++ b/unix.t
@@ -386,7 +386,7 @@ char buf[512];
 int n;
 
 for(;;){
-  n = read(0, buf, sizeof buf);
+  n = read(0, buf, sizeof(buf));
   if(n == 0)
     break;
   if(n < 0){


### PR DESCRIPTION
The source code on page 11 of https://pdos.csail.mit.edu/6.828/2017/xv6/book-rev10.pdf contains a syntax error (parameter of sizeof operator is not in parantheses). This patch should fix this syntax bug.