### PR TITLE
Clarify distinction between disk sector and OS block

### DIFF
--- a/fs.t
+++ b/fs.t
@@ -169,7 +169,7 @@ to be written to the disk.
 .line bio.c:/^bread/
 calls
 .code-index bget
-to get a buffer for the given sector
+to get a buffer for the given block
 .line bio.c:/b.=.bget/ .
 If the buffer needs to be read from disk,
 .code bread
@@ -179,7 +179,7 @@ to do that before returning the buffer.
 .PP
 .code Bget
 .line bio.c:/^bget/
-scans the buffer list for a buffer with the given device and sector numbers
+scans the buffer list for a buffer with the given device and block numbers
 .lines bio.c:/Is.the.block.already/,/^..}/ .
 If there is such a buffer,
 .code-index bget
@@ -187,15 +187,15 @@ acquires the sleep-lock for the buffer.
 .code bget
 then returns the locked buffer.
 .PP
-If there is no cached buffer for the given sector,
+If there is no cached buffer for the given block,
 .code-index bget
 must make one, possibly reusing a buffer that held
-a different sector.
+a different block.
 It scans the buffer list a second time, looking for a buffer
 that is not locked and not dirty:
 any such buffer can be used.
 .code Bget
-edits the buffer metadata to record the new device and sector number
+edits the buffer metadata to record the new device and block number
 and acquires its sleep-lock.
 Note that the assignment to
 .code flags
@@ -207,7 +207,7 @@ will read the block data from disk
 rather than incorrectly using the buffer's previous contents.
 .PP
 It is important that there is at most one cached buffer per
-disk sector, to ensure that readers see writes, and because the
+disk block, to ensure that readers see writes, and because the
 file system uses locks on buffers for synchronization.
 .code bget
 ensures this invariant by holding the
@@ -359,7 +359,7 @@ operation's writes appear on the disk, or none of them appear.
 The log resides at a known fixed location, specified in the superblock.
 It consists of a header block followed by a sequence
 of updated block copies (``logged blocks'').
-The header block contains an array of sector
+The header block contains an array of block
 numbers, one for each of the logged blocks, and 
 the count of log blocks.
 The count in the header block on disk is either
@@ -460,7 +460,7 @@ distinct blocks.
 .line log.c:/^log.write/
 acts as a proxy for 
 .code-index bwrite .
-It records the block's sector number in memory,
+It records the block number in memory,
 reserving it a slot in the log on disk,
 and marks the buffer
 .code B_DIRTY
@@ -533,7 +533,7 @@ The transaction looks like this:
       end_op();
 .P2
 This code is wrapped in a loop that breaks up large writes into individual
-transactions of just a few sectors at a time, to avoid overflowing
+transactions of just a few blocks at a time, to avoid overflowing
 the log.  The call to
 .code-index writei
 writes many blocks as part of this

--- a/trap.t
+++ b/trap.t
@@ -788,11 +788,12 @@ from and back to the disk.  Disk hardware traditionally presents the data on the
 disk as a numbered sequence of 512-byte 
 .italic blocks 
 .index block
-(also called 
+(not to be confused with 
 .italic sectors ): 
 .index sector
-sector 0 is the first 512 bytes, sector 1 is the next, and so on. The block size
+block 0 is the first 512 bytes, block 1 is the next, and so on. The block size
 that an operating system uses for its file system maybe different than the
+hardware
 sector size that a disk uses, but typically the block size is a multiple of the
 sector size.  Xv6's block size is identical to the disk's sector size.  To
 represent a block xv6 has a structure
@@ -801,7 +802,7 @@ represent a block xv6 has a structure
 The
 data stored in this structure is often out of sync with the disk: it might have
 not yet been read in from disk (the disk is working on it but hasn't returned
-the sector's content yet), or it might have been updated but not yet written
+the block's content yet), or it might have been updated but not yet written
 out.  The driver must ensure that the rest of xv6 doesn't get confused when the
 structure is out of sync with the disk.
 .\"
@@ -826,11 +827,11 @@ each buffer represents the contents of one sector on a particular
 disk device.  The
 .code dev
 and
-.code sector
-fields give the device and sector
+.code blockno
+fields give the device and block
 number and the
 .code data
-field is an in-memory copy of the disk sector.
+field is an in-memory copy of the corresponding sector(s) on disk.
 Although the xv6 file system chooses
 .code BSIZE
 to be identical to the IDE's sector size, the driver can handle
@@ -968,7 +969,7 @@ the buffers ahead of it are taken care of.
 .PP
 .code Idestart
 .line ide.c:/^idestart/
-issues either a read or a write for the buffer's device and sector,
+issues either a read or a write for the buffer's device and block number,
 according to the flags.
 If the operation is a write,
 .code idestart


### PR DESCRIPTION
I suggest to set BSIZE to 1024 bytes in order to further clarify the difference between OS blocks and hardware disk sectors.