### PR TITLE
Changing the device memory size in mem.t

### DIFF
--- a/mem.t
+++ b/mem.t
@@ -173,7 +173,7 @@ addresses starting at
 so xv6 page tables including a direct mapping for them.
 Thus,
 .address PHYSTOP
-must be smaller than two gigabytes - 16 megabytes (for the device memory).
+must be smaller than two gigabytes - 32 megabytes (for the device memory).
 .PP
 Xv6 does not set the
 .code-index PTE_U


### PR DESCRIPTION
Top of memory is at 0xFFFFFFFF (4Gbyte) and device memory start at 0xFE000000 (according to fig. 2.2 known as xv6_layout).
So 0xFFFFFFFF - 0xFE000000 = 0x01FFFFFF (32 Mbyte).